### PR TITLE
Add cursor to visitor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,10 +93,10 @@ export default function reactTreeWalker(
       return undefined
     }
 
-    const recursive = (currentElement, currentContext) => {
+    const recursive = (currentElement, currentContext, cursor) => {
       if (Array.isArray(currentElement)) {
         return Promise.all(
-          currentElement.map(item => recursive(item, currentContext)),
+          currentElement.map(item => recursive(item, currentContext, cursor.concat(currentElement))),
         )
       }
 
@@ -109,7 +109,7 @@ export default function reactTreeWalker(
         typeof currentElement === 'number'
       ) {
         // Just visit these, they are leaves so we don't keep traversing.
-        safeVisitor(currentElement, null, currentContext)
+        safeVisitor(currentElement, null, currentContext, null, cursor)
         return Promise.resolve()
       }
 
@@ -127,6 +127,7 @@ export default function reactTreeWalker(
                 compInstance,
                 elContext,
                 childContext,
+                cursor,
               ),
             )
               .then(result => {
@@ -144,14 +145,14 @@ export default function reactTreeWalker(
                         children,
                         child =>
                           child
-                            ? recursive(child, childContext)
+                            ? recursive(child, childContext, cursor.concat(currentElement))
                             : Promise.resolve(),
                       )
                         .then(innerResolve, reject)
                         .catch(reject)
                     }
                     // Otherwise we pass the individual child to the next recursion.
-                    return recursive(children, childContext)
+                    return recursive(children, childContext, cursor.concat(currentElement))
                       .then(innerResolve, reject)
                       .catch(reject)
                   }
@@ -252,7 +253,7 @@ export default function reactTreeWalker(
       ) {
         return Promise.all(
           currentElement.children.props.children.map(child =>
-            recursive(child, currentContext),
+            recursive(child, currentContext, cursor.concat(currentElement)),
           ),
         )
       }
@@ -260,6 +261,6 @@ export default function reactTreeWalker(
       return Promise.resolve()
     }
 
-    recursive(tree, context).then(resolve, reject)
+    recursive(tree, context, []).then(resolve, reject)
   })
 }


### PR DESCRIPTION
This lets us do stuff that depends on knowing where the node we're visiting is.

For example, I noticed `<v:roundrect />` is invalid but `React.createElement('v:roundrect')` is fine, so wrote some code like `<v$roundrect />` & a function that can find replace `$` with `:`.

```js
const React = require('react')
const ReactWalker = require('./reactTreeWalker').default

const ReactMapper = async (element, f) => {
  let root
  let next = new Map()
  await ReactWalker(
    element,
    (e, _0, _1, _2, cursor) => {
      if (typeof e.type === 'function') return
      if (e.type && e.type.toString().includes('react.fragment')) return

      const parent = cursor.filter(e => typeof e.type === 'string').slice(-1)[0]

      let ni
      if (typeof e.type === 'string') {
        ni = f(e)
        ni.children = []
        next.set(e, ni)
      }
      if (parent) next.get(parent).children.push(ni || e)
      if (!root) root = ni
    },
    {}
  )

  const recursive = el => {
    if (typeof el === 'string' || typeof el === 'number') return el
    const {type, props, children} = el
    return React.createElement(type, props, ...children.map(recursive))
  }

  return recursive(root)
}

const repairNamespaces = async element => {
  element = await ReactMapper(element, e => {
    const type = e.type.replace('$', ':')
    const props = e.props
    return {type, props}
  })

  return element
}
```