### PR TITLE
Add support for React.forwardRef

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -467,5 +467,26 @@ describe('reactTreeWalker', () => {
         expect(actual).toEqual(expected)
       })
     })
+
+    it('supports forwardRef', () => {
+      class Foo extends ReactComponent {
+        render() {
+          return this.props.children
+        }
+      }
+
+      const Bar = React.forwardRef((props, ref) => <Foo ref={ref} {...props} />)
+
+      const tree = <Bar>foo</Bar>
+
+      const elements = []
+      return reactTreeWalker(tree, element => {
+        elements.push(element)
+      }).then(() => {
+        expect(elements.pop()).toBe('foo')
+        expect(elements.pop().type).toBe(Foo)
+        expect(elements.pop().type).toBe(Bar)
+      })
+    })
   })
 })


### PR DESCRIPTION
I'm not that familiar with this module, but this seems to fix #38.

It uses the internal $$typeof property from React. I didn't test it with Preact, but I couldn't find anything about forwardRef in Preact so I think it doesn't exist yet.